### PR TITLE
Fix logging and CONFIG in petals

### DIFF
--- a/climada_petals/__init__.py
+++ b/climada_petals/__init__.py
@@ -22,12 +22,8 @@ from shutil import copyfile
 from pathlib import Path
 
 import climada
-from climada.util.config import setup_logging
-from .util.config import CONFIG
+import climada_petals.util.config
 from .util.constants import *
-
-
-__all__ = ['init']
 
 REPO_DATA = {
     'data/system': [
@@ -40,22 +36,11 @@ REPO_DATA = {
 }
 
 
-def setup_climada_data(reload=False):
-
-    for dirpath in [DEMO_DIR, SYSTEM_DIR]:
-        dirpath.mkdir(parents=True, exist_ok=True)
-
+def copy_repo_data(reload=False):
     for src_dir, path_list in REPO_DATA.items():
         for path in path_list:
             if not path.exists() or reload:
                 src = Path(__file__).parent.parent.joinpath(src_dir, path.name)
                 copyfile(src, path)
 
-
-def init():
-    climada.init()
-    setup_climada_data()
-    setup_logging(CONFIG.log_level.str())
-
-
-init()
+copy_repo_data()

--- a/climada_petals/util/config.py
+++ b/climada_petals/util/config.py
@@ -24,21 +24,27 @@ __all__ = [
 ]
 
 
+import logging
 from pathlib import Path
 
 import climada
 import climada.util.config
-from climada.util.config import Config, _fetch_conf, CONFIG_NAME, CONFIG
+from climada.util.config import (
+    Config, _fetch_conf, CONFIG_NAME, CONFIG, remove_handlers, CONSOLE)
+
+LOGGER = logging.getLogger('climada_petals')
+LOGGER.propagate = False
+remove_handlers(LOGGER)
+LOGGER.addHandler(CONSOLE)
 
 CORE_DIR = Path(climada.__file__).parent
 SOURCE_DIR = Path(__file__).absolute().parent.parent
 
-climada.util.config.CONFIG = Config.from_dict(_fetch_conf([
+CONFIG.__dict__ = Config.from_dict(_fetch_conf([
     CORE_DIR / 'conf',  # default config from the climada repository
     SOURCE_DIR / 'conf',  # default config from the climada_petals repository
     Path.home() / 'climada' / 'conf',  # ~/climada/conf directory
     Path.home() / '.config',  # ~/.config directory
     Path.cwd(),  # current working directory
-], CONFIG_NAME))
-
-climada.CONFIG = climada.util.config.CONFIG
+], CONFIG_NAME)).__dict__
+LOGGER.setLevel(getattr(logging, CONFIG.log_level.str()))


### PR DESCRIPTION
This PR makes sure that the top-level logger `"climada_petals"` is set up correctly so that it's behavior agrees with that of the `"climada"` logger. Previously, the top-level logger wasn't set up at all so that all logging was propagated to the default root looger and used the configuration of that logger (whichever that was).

Additionally, this PR fixes the `CONFIG` object when using `climada_petals`. The previous attempts to overwrite CLIMADA's pre-defined `CONFIG` object in `climada_petals.util.config` cause several problems, especially the parallel existence of inconsistent `CONFIG` objects in the user namespace:
```
>>> from climada_petals.util.config import CONFIG
>>> CONFIG.hazard.drought
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Config' object has no attribute 'drought'
>>> from climada import CONFIG
>>> CONFIG.hazard.drought
{resources: {spei_file_url: http://digital.csic.es/bitstream/10261/153475/8}}
```