### PR TITLE
Deprecate set and read constructors in exposures 

### DIFF
--- a/climada_petals/engine/test/test_supplychain.py
+++ b/climada_petals/engine/test/test_supplychain.py
@@ -85,8 +85,7 @@ class TestSupplyChain(unittest.TestCase):
 
         # Read demo entity values
         # Set the entity default file to the demo one
-        exp = Exposures()
-        exp.read_hdf5(EXP_DEMO_H5)
+        exp = Exposures.from_hdf5(EXP_DEMO_H5)
         exp.check()
         exp.gdf.region_id = 840 #assign right id for USA
         exp.assign_centroids(hazard)
@@ -199,8 +198,7 @@ class TestSupplyChain(unittest.TestCase):
 
         # Read demo entity values
         # Set the entity default file to the demo one
-        exp = Exposures()
-        exp.read_hdf5(EXP_DEMO_H5)
+        exp = Exposures.from_hdf5(EXP_DEMO_H5)
         exp.check()
         exp.gdf.region_id = 840 #assign right id for USA
         exp.assign_centroids(hazard)
@@ -256,8 +254,7 @@ class TestSupplyChain(unittest.TestCase):
 
         # Read demo entity values
         # Set the entity default file to the demo one
-        exp = Exposures()
-        exp.read_hdf5(EXP_DEMO_H5)
+        exp = Exposures.from_hdf5(EXP_DEMO_H5)
         exp.check()
         exp.gdf.region_id = 840 #assign right id for USA
         exp.assign_centroids(hazard)

--- a/climada_petals/entity/exposures/crop_production.py
+++ b/climada_petals/entity/exposures/crop_production.py
@@ -1048,12 +1048,10 @@ def normalize_several_exp(input_dir=None, output_dir=None,
     for file_firr in filenames_firr:
         _, _, crop_irr, years = file_firr.split('_')
         crop, _ = crop_irr.split('-')
-        exp_firr = CropProduction()
-        exp_firr.read_hdf5(str(Path(output_dir, 'Exposure', file_firr)))
+        exp_firr = CropProduction.from_hdf5(str(Path(output_dir, 'Exposure', file_firr)))
 
         filename_noirr = 'crop_production_' + crop + '-' + 'noirr' + '_' + years
-        exp_noirr = CropProduction()
-        exp_noirr.read_hdf5(str(Path(output_dir, 'Exposure', filename_noirr)))
+        exp_noirr = CropProduction.from_hdf5(str(Path(output_dir, 'Exposure', filename_noirr)))
 
         if return_data:
             countries, ratio, exp_firr2, exp_noirr2, fao_cp, \


### PR DESCRIPTION
Only read_hdf5() is used in Petals (set_from_raster and read_mat are not used).