### PR TITLE
Fix tc_surge_bathtub tests for climada_python#339

### DIFF
--- a/climada_petals/hazard/tc_surge_bathtub.py
+++ b/climada_petals/hazard/tc_surge_bathtub.py
@@ -175,7 +175,7 @@ def _fraction_on_land(centroids, topo_path):
 
     read_raster_buffer = 0.5 * max(np.abs(cen_trans[0]), np.abs(cen_trans[4]))
     bounds += read_raster_buffer * np.array([-1., -1., 1., 1.])
-    on_land, dem_trans = u_coord.read_raster_bounds(topo_path, bounds)
+    on_land, dem_trans = u_coord.read_raster_bounds(topo_path, bounds, resampling="bilinear")
     on_land = (on_land > 0).astype(np.float64)
 
     with rasterio.open(topo_path, 'r') as src:

--- a/climada_petals/hazard/test/test_tc_surge_bathtub.py
+++ b/climada_petals/hazard/test/test_tc_surge_bathtub.py
@@ -111,7 +111,7 @@ class TestTCSurgeBathtub(unittest.TestCase):
         # check individual known pixel values
         self.assertAlmostEqual(fraction[24, 10], 0.0)
         self.assertAlmostEqual(fraction[22, 11], 0.21)
-        self.assertAlmostEqual(fraction[22, 12], 0.93)
+        self.assertAlmostEqual(fraction[22, 12], 0.94)
         self.assertAlmostEqual(fraction[21, 14], 1.0)
 
 


### PR DESCRIPTION
This fixes the tests for tc_surge_bathtub according to the changes to the function `read_raster_bounds` in the core repository (https://github.com/CLIMADA-project/climada_python/pull/339).