### PR TITLE
Adding argument to discard duplicate tracks

### DIFF
--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -95,7 +95,7 @@ class TCForecast(TCTracks):
                                deterministic run)
     """
 
-    def fetch_ecmwf(self, path=None, files=None, target_dir=None, remote_dir=None, read_det=False):
+    def fetch_ecmwf(self, path=None, files=None, target_dir=None, remote_dir=None):
         """
         Fetch and read latest ECMWF TC track predictions from the FTP
         dissemination server into instance. Use path or files argument


### PR DESCRIPTION
For the named TC from ECMWF ensemble forecast (e.g. TIFFANY and CODY at the time this pull request is made), the FTP folder provides an extra bufr files (name pattern `*ECMF*`) that _**only**_ contains the high resolution deterministic forecast track (ensemble id. 52). However, this track is also included in the regular bufr file that contains the full set of ensemble forecasts (ensemble id. 1-52). The current method reads all the TC bufr files and therefore, the deterministic forecast track with ensemble id 52 would duplicate. 

An update of this pull request that adds an argument `read_det` with default set to `False` that reads only the ensemble forecast (the bufr file that contains track with ensemble id 1-52). If set to `True` then it reads all the available bufr files from the FTP server, which includes the bufr file that contains the single deterministic run. This argument only works for reading bufr files from ECMWF FTP server.