### PR TITLE
Feature/tc forecast hdf5

### DIFF
--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -94,7 +94,7 @@ class TCForecast(TCTracks):
         - ensemble_member (int)
         - is_ensemble (bool; if False, the simulation is a high resolution
                        deterministic run)
-        - forecast_time (numpy.datetime64): timepoint of the initialisation of
+        - run_datetime (numpy.datetime64): timepoint of the initialisation of
             the numerical weather prediction run
 
     """
@@ -380,15 +380,15 @@ class TCForecast(TCTracks):
         # change dtype from bool to int to be NetCDF4-compliant, this is undone later
         for track in self.data:
             track.attrs['is_ensemble'] = int(track.attrs['is_ensemble'])
-            track.attrs['forecast_time'] = str(track.attrs['forecast_time'])
+            track.attrs['run_datetime'] = str(track.attrs['run_datetime'])
         try:
             super().write_hdf5(file_name=file_name, complevel=complevel)
         finally:
             # ensure to undo the temporal change of dtype from above
             for track in self.data:
                 track.attrs['is_ensemble'] = bool(track.attrs['is_ensemble'])
-                track.attrs['forecast_time'] = np.datetime64(
-                    track.attrs['forecast_time']
+                track.attrs['run_datetime'] = np.datetime64(
+                    track.attrs['run_datetime']
                     )
 
 
@@ -409,8 +409,8 @@ class TCForecast(TCTracks):
         tracks.data = temp.data
         for track in tracks.data:
             track.attrs['is_ensemble'] = bool(track.attrs['is_ensemble'])
-            track.attrs['forecast_time'] = np.datetime64(
-                track.attrs['forecast_time']
+            track.attrs['run_datetime'] = np.datetime64(
+                track.attrs['run_datetime']
                 )
         return tracks
 
@@ -468,7 +468,7 @@ class TCForecast(TCTracks):
                     'id_no': (int(id_no) + index / 100),
                     'ensemble_number': msg['ens_number'][index],
                     'is_ensemble': ens_bool,
-                    'forecast_time': timestamp_origin,
+                    'run_datetime': timestamp_origin,
                 }
             )
         except ValueError as err:

--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -92,7 +92,11 @@ class TCForecast(TCTracks):
     data : list of xarray.Dataset
         Same as in parent class, adding the following attributes
         - ensemble_member (int)
-        - is_ensemble (bool; if False, the simulation is a high resolution deterministic run
+        - is_ensemble (bool; if False, the simulation is a high resolution
+                       deterministic run)
+        - forecast_time (numpy.datetime64): timepoint of the initialisation of
+            the numerical weather prediction run
+
     """
 
     def fetch_ecmwf(self, path=None, files=None, target_dir=None, remote_dir=None):

--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -385,7 +385,7 @@ class TCForecast(TCTracks):
             super().write_hdf5(file_name=file_name, complevel=complevel)
         finally:
             # ensure to undo the temporal change of dtype from above
-            for i, track in enumerate(self.data):
+            for track in self.data:
                 track.attrs['is_ensemble'] = bool(track.attrs['is_ensemble'])
                 track.attrs['forecast_time'] = np.datetime64(
                     track.attrs['forecast_time']

--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -378,7 +378,7 @@ class TCForecast(TCTracks):
             A value of 0 or None disables compression. Default: 5
         """
         # change dtype from bool to int to be NetCDF4-compliant, this is undone later
-        for i, track in enumerate(self.data):
+        for track in self.data:
             track.attrs['is_ensemble'] = int(track.attrs['is_ensemble'])
             track.attrs['forecast_time'] = str(track.attrs['forecast_time'])
         try:
@@ -407,7 +407,7 @@ class TCForecast(TCTracks):
         temp = super().from_hdf5(file_name = file_name)
         tracks = TCForecast()
         tracks.data = temp.data
-        for i, track in enumerate(tracks.data):
+        for track in tracks.data:
             track.attrs['is_ensemble'] = bool(track.attrs['is_ensemble'])
             track.attrs['forecast_time'] = np.datetime64(
                 track.attrs['forecast_time']

--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -447,7 +447,7 @@ class TCForecast(TCTracks):
         )
 
         # according to specs always num-num-letter
-        track['basin'] = ('time', np.full_like(track.time, BASINS[sid[2]], dtype=object))
+        track['basin'] = ('time', np.full_like(track.time, sid[2], dtype='<U2'))
 
         if sid[2] == 'X':
             LOGGER.info(

--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -452,11 +452,11 @@ class TCForecast(TCTracks):
                     'max_sustained_wind': ('time', np.squeeze(wnd)),
                     'central_pressure': ('time', np.squeeze(pre)/100),
                     'ts_int': ('time', timestep_int),
-                    'lat': ('time', lat),
-                    'lon': ('time', lon),
                 },
                 coords={
                     'time': timestamp,
+                    'lat': ('time', lat),
+                    'lon': ('time', lon),
                 },
                 attrs={
                     'max_sustained_wind_unit': 'm/s',

--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -366,6 +366,53 @@ class TCForecast(TCTracks):
             else:
                 LOGGER.debug('Dropping empty track %s, subset %d', name, i)
 
+    def write_hdf5(self, file_name, complevel=5):
+        """Write TC tracks in NetCDF4-compliant HDF5 format. This method
+        overrides the method of the base class.
+        Parameters
+        ----------
+        file_name: str or Path
+            Path to a new HDF5 file. If it exists already, the file is overwritten.
+        complevel : int
+            Specifies a compression level (0-9) for the zlib compression of the data.
+            A value of 0 or None disables compression. Default: 5
+        """
+        # change dtype from bool to int to be NetCDF4-compliant, this is undone later
+        for i, track in enumerate(self.data):
+            track.attrs['is_ensemble'] = int(track.attrs['is_ensemble'])
+            track.attrs['forecast_time'] = str(track.attrs['forecast_time'])
+        try:
+            super().write_hdf5(file_name=file_name, complevel=complevel)
+        finally:
+            # ensure to undo the temporal change of dtype from above
+            for i, track in enumerate(self.data):
+                track.attrs['is_ensemble'] = bool(track.attrs['is_ensemble'])
+                track.attrs['forecast_time'] = np.datetime64(
+                    track.attrs['forecast_time']
+                    )
+
+
+    @classmethod
+    def from_hdf5(cls, file_name):
+        """Create new TCTracks object from a NetCDF4-compliant HDF5 file
+        Parameters. This method overrides the method of the base class.
+        ----------
+        file_name : str or Path
+            Path to a file that has been generated with `TCForecast.write_hdf`.
+        Returns
+        -------
+        tracks : TCForecast
+            TCTracks with data from the given HDF5 file.
+        """
+        temp = super().from_hdf5(file_name = file_name)
+        tracks = TCForecast()
+        tracks.data = temp.data
+        for i, track in enumerate(tracks.data):
+            track.attrs['is_ensemble'] = bool(track.attrs['is_ensemble'])
+            track.attrs['forecast_time'] = np.datetime64(
+                track.attrs['forecast_time']
+                )
+        return tracks
 
     @staticmethod
     def get_value_from_bufr_array(var):

--- a/climada_petals/hazard/test/test_tc_tracks_forecast.py
+++ b/climada_petals/hazard/test/test_tc_tracks_forecast.py
@@ -59,7 +59,7 @@ class TestECMWF(unittest.TestCase):
         self.assertEqual(forecast.data[1].name, 'HEROLD')
         np.testing.assert_array_equal(forecast.data[0].basin, 'S')
         self.assertEqual(forecast.data[0].category, 'Tropical Depression')
-        self.assertEqual(forecast.data[0].forecast_time,
+        self.assertEqual(forecast.data[0].run_datetime,
                          np.datetime64('2020-03-19T12:00:00.000000'))
         self.assertEqual(forecast.data[1].is_ensemble, True)
 

--- a/climada_petals/hazard/test/test_tc_tracks_forecast.py
+++ b/climada_petals/hazard/test/test_tc_tracks_forecast.py
@@ -57,7 +57,7 @@ class TestECMWF(unittest.TestCase):
         self.assertEqual(forecast.data[0].central_pressure_unit, 'mb')
         self.assertEqual(forecast.data[1].sid, '22S')
         self.assertEqual(forecast.data[1].name, 'HEROLD')
-        np.testing.assert_array_equal(forecast.data[0].basin, 'S - South-West Indian Ocean')
+        np.testing.assert_array_equal(forecast.data[0].basin, 'S')
         self.assertEqual(forecast.data[0].category, 'Tropical Depression')
         self.assertEqual(forecast.data[0].forecast_time,
                          np.datetime64('2020-03-19T12:00:00.000000'))

--- a/climada_petals/test/test_tc_forecast_integr.py
+++ b/climada_petals/test/test_tc_forecast_integr.py
@@ -72,7 +72,7 @@ class TestTCForecast(unittest.TestCase):
         self.assertIsInstance(tr_forecast.data[0].id_no, float)
         self.assertIsInstance(tr_forecast.data[0].ensemble_number, np.integer)
         self.assertIsInstance(tr_forecast.data[1].is_ensemble, np.bool_)
-        self.assertIsInstance(tr_forecast.data[0].forecast_time, np.datetime64)
+        self.assertIsInstance(tr_forecast.data[0].run_datetime, np.datetime64)
         self.assertIsInstance(tr_forecast.data[0].category, str)
 
     def test_compute_TC_windfield_from_ecmwf(self):


### PR DESCRIPTION
Hdf5 input and output have been added to the TCTracks baseclass in this pull request in climada_python: https://github.com/CLIMADA-project/climada_python/pull/349
This pull request makes sure this added funtionality does not fail in TCForecast which inherits from TCTracks.
(1) I have overloaded the methods write_hdf5 and from_hdf5
(2) I have changed the 'basin' attribute to dtype '<U2', (this decision was made in the baseclass TCTracks for details see the pull request mentioned above)
(3) I added the forecast_time attribute to the docstring of the TCForecast class

I took over the decisions on code structure/docstring etc from the pullrequest mentioned above to be on the same line as the baseclass.