### PR TITLE
Fix event_id starting at 0 in RiverFlood

### DIFF
--- a/climada_petals/hazard/river_flood.py
+++ b/climada_petals/hazard/river_flood.py
@@ -231,7 +231,7 @@ class RiverFlood(Hazard):
 
         haz.units = 'm'
         haz.tag.file_name = str(dph_path) + ';' + str(frc_path)
-        haz.event_id = np.arange(haz.intensity.shape[0])
+        haz.event_id = np.arange(1, haz.intensity.shape[0] + 1)
         haz.event_name = list(map(str, years))
 
         if origin:

--- a/climada_petals/hazard/test/test_flood.py
+++ b/climada_petals/hazard/test/test_flood.py
@@ -93,7 +93,7 @@ class TestRiverFlood(unittest.TestCase):
         rf = RiverFlood.from_nc(dph_path=HAZ_DEMO_FLDDPH, frc_path=HAZ_DEMO_FLDFRC,
                        countries=['DEU'], ISINatIDGrid=True)
         self.assertEqual(rf.date[0], 730303)
-        self.assertEqual(rf.event_id[0], 0)
+        self.assertEqual(rf.event_id[0], 1)
         self.assertEqual(rf.event_name[0], '2000')
         self.assertEqual(rf.orig[0], False)
         self.assertAlmostEqual(rf.frequency[0], 1.)
@@ -123,7 +123,7 @@ class TestRiverFlood(unittest.TestCase):
                        countries=['DEU'])
 
         self.assertEqual(rf.date[0], 730303)
-        self.assertEqual(rf.event_id[0], 0)
+        self.assertEqual(rf.event_id[0], 1)
         self.assertEqual(rf.event_name[0], '2000')
         self.assertEqual(rf.orig[0], False)
         self.assertAlmostEqual(rf.frequency[0], 1.)
@@ -149,7 +149,7 @@ class TestRiverFlood(unittest.TestCase):
                        centroids=rand_centroids, ISINatIDGrid=False)
 
         self.assertEqual(rf.date[0], 730303)
-        self.assertEqual(rf.event_id[0], 0)
+        self.assertEqual(rf.event_id[0], 1)
         self.assertEqual(rf.event_name[0], '2000')
         self.assertEqual(rf.orig[0], False)
         self.assertAlmostEqual(rf.frequency[0], 1.)


### PR DESCRIPTION
This fixes a small bug where `event_id` would always start at 0 in `RiverFlood`. According to [the docs](https://climada-python.readthedocs.io/en/stable/climada/climada.hazard.html?highlight=check#climada.hazard.base.Hazard.event_id) of the `Hazard` base class, `event_id` is supposed to be greater zero. The bug prevented, e.g., plotting the hazard intensity of the first event, because `plot_intensity(event=0)` plots the maximum intensity over all events [by convention](https://climada-python.readthedocs.io/en/stable/climada/climada.hazard.html?highlight=check#climada.hazard.base.Hazard.plot_intensity).

There are two minor issues one might like to discuss:
* This problem is not detected by the `check()` method.
* The `check()` method is never executed in the `RiverFlood` unit tests.