### PR TITLE
tc_surge_bathtub: improve performance of sparse matrix operations

### DIFF
--- a/climada_petals/hazard/tc_surge_bathtub.py
+++ b/climada_petals/hazard/tc_surge_bathtub.py
@@ -26,7 +26,6 @@ import logging
 
 import numpy as np
 import rasterio.warp
-import scipy.sparse as sp
 
 from climada.hazard.base import Hazard
 import climada.util.coordinates as u_coord


### PR DESCRIPTION
This PR greatly improves the performance of the sparse matrix operations in the tc_surge_bathtub hazard module. It reduces the amount of memory required during the computation and for storing the result, and it reduces the computational time considerably. No functionality, and hence no unit tests are affected by these changes.

More details in the comments below.