### PR TITLE
Adapt tc_forecast to climada_python improved hdf5 IO

### DIFF
--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -518,8 +518,8 @@ class TCForecast(TCTracks):
 
         # can only make latlon coords after dropna
         track = track.set_coords(['lat', 'lon'])
-        track['time_step'] = track.ts_int - \
-            track.ts_int.shift({'time': 1}, fill_value=0)
+        track['time_step'] = (track.ts_int - \
+            track.ts_int.shift({'time': 1}, fill_value=0)).astype(float)
 
         track = track.drop_vars(['ts_int'])
 

--- a/climada_petals/hazard/test/test_tc_tracks_forecast.py
+++ b/climada_petals/hazard/test/test_tc_tracks_forecast.py
@@ -60,6 +60,7 @@ class TestECMWF(unittest.TestCase):
         self.assertEqual(forecast.data[1].lat[2], -27.)
         self.assertEqual(forecast.data[0].lon[2], 73.5)
         self.assertEqual(forecast.data[1].time_step[2], 6)
+        self.assertEqual(forecast.data[1].time_step.dtype, np.float64)
         self.assertEqual(forecast.data[1].max_sustained_wind[2], 14.9)
         self.assertEqual(forecast.data[0].central_pressure[1], 1000.)
         self.assertEqual(forecast.data[0]['time.year'][1], 2020)
@@ -177,6 +178,7 @@ class TestCXML(unittest.TestCase):
             forecast.data[2].run_datetime,
             pd.Timestamp('2022-03-02 12:00:00+0000', tz='UTC'),
         )
+        self.assertEqual(forecast.data[1].time_step.dtype, np.float64)
         self.assertTrue(forecast.data[4].is_ensemble)
 
     def test_custom_xsl(self):


### PR DESCRIPTION
Changes proposed in this PR:
- cast "time" values to `float` when reading bufr file in `read_one_bufr_tc`
  I suspect that with climada_python PR [#735](https://github.com/CLIMADA-project/climada_python/pull/735) time values are of dtype float when read from hdf5 (which makes sense too). But so far `time` has been an int.

This PR fixes failing of `climada_petals.hazard.test.test_tc_tracks_forecast.TestECMWF.test_hdf5_io` due to type differences in `tc_track` from bufr file and `tc_read` from hdf5

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html#Static-Code-Analysis
