### PR TITLE
implicit casting for dt.datetime

### DIFF
--- a/climada_petals/hazard/river_flood.py
+++ b/climada_petals/hazard/river_flood.py
@@ -235,9 +235,10 @@ class RiverFlood(Hazard):
 
         with xr.open_dataset(dph_path) as flood_dph:
             haz.date = np.array([
-                dt.datetime(int(flood_dph.time[i].dt.year),
-                            int(flood_dph.time[i].dt.month),
-                            int(flood_dph.time[i].dt.day)
+                dt.datetime(
+                    flood_dph.time.dt.year.values[i],
+                    flood_dph.time.dt.month.values[i],
+                    flood_dph.time.dt.day.values[i],
                 ).toordinal()
                 for i in event_index
             ])

--- a/climada_petals/hazard/river_flood.py
+++ b/climada_petals/hazard/river_flood.py
@@ -235,9 +235,10 @@ class RiverFlood(Hazard):
 
         with xr.open_dataset(dph_path) as flood_dph:
             haz.date = np.array([
-                dt.datetime(flood_dph.time[i].dt.year,
-                            flood_dph.time[i].dt.month,
-                            flood_dph.time[i].dt.day).toordinal()
+                dt.datetime(int(flood_dph.time[i].dt.year),
+                            int(flood_dph.time[i].dt.month),
+                            int(flood_dph.time[i].dt.day)
+                ).toordinal()
                 for i in event_index
             ])
 

--- a/climada_petals/hazard/tc_rainfield.py
+++ b/climada_petals/hazard/tc_rainfield.py
@@ -151,9 +151,9 @@ class TCRain(Hazard):
         new_haz.fraction.data.fill(1)
         # store date of start
         new_haz.date = np.array([dt.datetime(
-            int(track.time.dt.year[0]),
-            int(track.time.dt.month[0]),
-            int(track.time.dt.day[0])
+            track.time.dt.year.values[0],
+            track.time.dt.month.values[0],
+            track.time.dt.day.values[0],
         ).toordinal()])
         new_haz.orig = np.array([track.orig_event_flag])
         new_haz.category = np.array([track.category])

--- a/climada_petals/hazard/tc_rainfield.py
+++ b/climada_petals/hazard/tc_rainfield.py
@@ -151,8 +151,10 @@ class TCRain(Hazard):
         new_haz.fraction.data.fill(1)
         # store date of start
         new_haz.date = np.array([dt.datetime(
-            track.time.dt.year[0], track.time.dt.month[0],
-            track.time.dt.day[0]).toordinal()])
+            int(track.time.dt.year[0]),
+            int(track.time.dt.month[0]),
+            int(track.time.dt.day[0])
+        ).toordinal()])
         new_haz.orig = np.array([track.orig_event_flag])
         new_haz.category = np.array([track.category])
         new_haz.basin = [str(track.basin.values[0])]


### PR DESCRIPTION
Changes proposed in this PR:
- implicit casting to integer when calling `dt.datetime()`

This PR fixes #96

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html#Static-Code-Analysis
