### PR TITLE
Fix test_surge_from_track after change in Holland 2008 implementation…

### DIFF
--- a/climada_petals/hazard/test/test_tc_surge_bathtub.py
+++ b/climada_petals/hazard/test/test_tc_surge_bathtub.py
@@ -174,8 +174,8 @@ class TestTCSurgeBathtub(unittest.TestCase):
                 np.testing.assert_array_equal(inten[fraction == 0], 0)
 
                 # check individual known pixel values
-                self.assertAlmostEqual(inten[9, 31], max(-0.391 + slr, 0), places=2)
-                self.assertAlmostEqual(inten[14, 34] - slr, 3.637, places=2)
+                self.assertAlmostEqual(inten[9, 31], max(-1.219 + slr, 0), places=2)
+                self.assertAlmostEqual(inten[14, 34] - slr, 2.825, places=2)
 
 
 # Execute Tests


### PR DESCRIPTION
… (climada_python PR #833)

Changes proposed in this PR:
-  adapt test values after change in the windmodel in climada_python (introduced in pull request #833 in climada_python https://github.com/CLIMADA-project/climada_python/pull/833)
- 

This PR fixes #842 in climada_python https://github.com/CLIMADA-project/climada_python/issues/842 

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html#Static-Code-Analysis
