### PR TITLE
Only assign csr matrices to Hazard objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ Code freeze date: YYYY-MM-DD
 ### Changed
 
 - Adaptations to refactoring of the `climada.hazard.Centroids` class, to be compatible with `climada>=5.0` [#122](https://github.com/CLIMADA-project/climada_petals/pull/122)
+- Always assign `csr_matrix` to `Hazard.intensity` [#129](https://github.com/CLIMADA-project/climada_petals/pull/129)
 
 ### Fixed
 
 - Fix `climada.hazard.tc_rainfield` for TC tracks crossing the antimeridian [#105](https://github.com/CLIMADA-project/climada_petals/pull/105)
 - Update the table of content for the tutorials [#125](https://github.com/CLIMADA-project/climada_petals/pull/125)
+- Store all-zero fraction matrices in `LowFlow` and `WildFire` hazards [#129](https://github.com/CLIMADA-project/climada_petals/pull/129)
 
 ### Deprecated
 

--- a/climada_petals/hazard/low_flow.py
+++ b/climada_petals/hazard/low_flow.py
@@ -394,12 +394,11 @@ class LowFlow(Hazard):
         self.orig = np.ones(uniq_ev.size)
         self.set_frequency()
 
-        self.intensity = self._intensity_loop(uniq_ev, centroids.coord, res_centr, num_centr)
+        intensity = self._intensity_loop(uniq_ev, centroids.coord, res_centr, num_centr)
 
         # Following values are defined for each event and centroid
-        self.intensity = self.intensity.tocsr()
-        self.fraction = self.intensity.copy()
-        self.fraction.data.fill(1.0)
+        self.intensity = intensity.tocsr()
+        self.fraction = sparse.csr_matrix(self.intensity.shape)
 
     def identify_clusters(self, clus_thresh_xy=None, clus_thresh_t=None, min_samples=None):
         """call clustering functions to identify the clusters inside the dataframe

--- a/climada_petals/hazard/test/test_wildfire.py
+++ b/climada_petals/hazard/test/test_wildfire.py
@@ -236,7 +236,7 @@ class TestMethodsFirms(unittest.TestCase):
         self.assertTrue(isinstance(wf.fraction, sparse.csr_matrix))
         self.assertEqual(wf.intensity.shape, (7, 19454))
         self.assertEqual(wf.fraction.shape, (7, 19454))
-        self.assertEqual(wf.fraction.max(), 1.0)
+        self.assertEqual(wf.fraction.nnz, 0)  # Zero everywhere means 1 everywhere
         self.assertAlmostEqual(wf.intensity[0, 16618], firms.loc[100].brightness)
         self.assertAlmostEqual(wf.intensity[1, 123], max(firms.loc[6721].brightness, firms.loc[6722].brightness))
         self.assertAlmostEqual(wf.intensity[2, :].max(), firms.loc[8105].brightness)

--- a/climada_petals/hazard/wildfire.py
+++ b/climada_petals/hazard/wildfire.py
@@ -899,12 +899,11 @@ class WildFire(Hazard):
         self._set_frequency()
 
         # Following values are defined for each fire and centroid
-        self.intensity = sparse.lil_matrix(np.zeros((num_ev, num_centr)))
+        intensity = sparse.lil_matrix(np.zeros((num_ev, num_centr)))
         for idx, ev_bright in enumerate(bright_list):
-            self.intensity[idx] = ev_bright
-        self.intensity = self.intensity.tocsr()
-        self.fraction = self.intensity.copy()
-        self.fraction.data.fill(1.0)
+            intensity[idx] = ev_bright
+        self.intensity = intensity.tocsr()
+        self.fraction = sparse.csr_matrix(self.intensity.shape)
 
     @staticmethod
     def _brightness_one_fire(df_firms, tree_centr, ev_id, res_centr, num_centr):


### PR DESCRIPTION


Changes proposed in this PR:
* Use intermediate variables if LIL matrices are used.
* Write all-zero fraction matrix instead of all-ones (all-zero fractions are treated as ones).

This PR fixes compatibility issues arising from CLIMADA-project/climada_python#893

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html#Static-Code-Analysis
