### PR TITLE
default installation with python 3.11

### DIFF
--- a/script/jenkins/install_env.sh
+++ b/script/jenkins/install_env.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 mamba env remove -n petals_env
-mamba create -n petals_env python=3.9
+mamba create -n petals_env python=3.11
 mamba env update -n petals_env -f ~/jobs/climada_install_env/workspace/requirements/env_climada.yml
 mamba env update -n petals_env -f requirements/env_climada.yml
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
 
     classifiers=[
         'Development Status :: 4 - Beta',
-        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3',
         'Topic :: Scientific/Engineering :: Atmospheric Science',
         'Topic :: Scientific/Engineering :: GIS',
         'Topic :: Scientific/Engineering :: Mathematics',


### PR DESCRIPTION
Changes proposed in this PR:

- Adjust doc and config file so that they point to python 3.11 as the default version

This PR fixes #

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html#Static-Code-Analysis
