### PR TITLE
Reduce centroid resolution from 30/60/60 to 0.1 in test

### DIFF
--- a/climada_petals/hazard/tc_surge_geoclaw/test/test_tc_surge_geoclaw.py
+++ b/climada_petals/hazard/tc_surge_geoclaw/test/test_tc_surge_geoclaw.py
@@ -80,7 +80,7 @@ class TestHazardInit(unittest.TestCase):
         topo_path = _test_bathymetry_tif()
 
         # first run, with automatic centroids
-        centroids = tracks.generate_centroids(res_deg=30 / (60 * 60), buffer_deg=5.5)
+        centroids = tracks.generate_centroids(res_deg=0.1, buffer_deg=5.5)
         haz = TCSurgeGeoClaw.from_tc_tracks(tracks, centroids, topo_path)
         self.assertIsInstance(haz, TCSurgeGeoClaw)
         self.assertEqual(haz.intensity.shape[0], 2)


### PR DESCRIPTION
Changes proposed in this PR:
- Reduce the centroids resolution from 30/60/60 to 0.1 in the unit test for GeoClaw form tracks.

This PR partially fixes #148 
