### PR TITLE
Added function to download data from Copernicus data stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Added:
 ### Added
 
 - Included `boario` in the supplychain module [#81](https://github.com/CLIMADA-project/climada_petals/pull/81/)
+- Added a Copernicus download function `downloader.py` as part of the `climada.hazard.copernicus_interface` module under construction [#150](https://github.com/CLIMADA-project/climada_petals/pull/150/)
 
 ### Changed
 

--- a/climada_petals/conf/climada.conf
+++ b/climada_petals/conf/climada.conf
@@ -54,6 +54,10 @@
                     "passwd": "essential"
                 }
             }
+        },
+        "copernicus": {
+            "local_data": "{local_data.system}/copernicus_data",
+            "seasonal_forecasts": "{local_data.system}/copernicus_data/seasonal_forecasts"
         }
     }
 }

--- a/climada_petals/hazard/copernicus_interface/downloader.py
+++ b/climada_petals/hazard/copernicus_interface/downloader.py
@@ -1,0 +1,155 @@
+"""
+This file is part of CLIMADA.
+
+Copyright (C) 2017 ETH Zurich, CLIMADA contributors listed in AUTHORS.
+
+CLIMADA is free software: you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free
+Software Foundation, version 3.
+
+CLIMADA is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
+
+---
+
+Functionality to download data from the Copernicus Data Stores.
+
+---
+
+Prerequisites:
+1. CDS API client installation:
+   pip install cdsapi
+
+2. CDS account and API key:
+   Register at https://cds.climate.copernicus.eu
+
+3. CDS API configuration:
+   Create a .cdsapirc file in your home directory with your API key and URL of the CDS you want to access.
+   For instance, if you want to access the Climate Data Store, see here for instructions:
+   https://cds.climate.copernicus.eu/how-to-api#install-the-cds-api-client
+
+4. Dataset Terms and Conditions: After selecting the dataset to download, make 
+   sure to accept the terms and conditions on the corresponding dataset webpage 
+   in the CDS portal before running the script.
+"""
+
+import logging
+import cdsapi
+from pathlib import Path
+
+from climada import CONFIG
+
+DATA_DIR = CONFIG.hazard.copernicus.local_data.dir()
+LOGGER = logging.getLogger(__name__)
+
+
+def download_data(dataset, params, filename=None, datastore_url=None, overwrite=False):
+    """Download data from Copernicus Data Stores (e.g., ds.climate.copernicus.eu,
+    ads.atmosphere.copernicus.eu and ewds.climate.copernicus.eu) using specified dataset type and parameters.
+
+    Parameters
+    ----------
+    dataset : str
+        The dataset to retrieve (e.g., 'seasonal-original-single-levels', 'sis-heat-and-cold-spells').
+    params : dict
+        Dictionary containing the parameters for the CDS API call (e.g., variables, time range, area).
+    filename : pathlib.Path or str
+        Full path and filename where the downloaded data will be stored. If None, data will be saved with the filename as suggested by the data store. Defaults to None.
+    datastore_url : str
+        Url of the Copernicus data store to be accessed. If None, the url of the .cdsapirc file is used. Defaults to None.
+    overwrite : bool, optional
+        If True, overwrite the file if it already exists. If False, skip downloading
+        if the file is already present. The default is False.
+
+    Raises
+    ------
+    FileNotFoundError
+        Raised if the download attempt fails and the file is not found at the specified location.
+    Exception
+        Raised for any other error during the download process, with further details corresponding to typical errors.
+    """
+
+    # Warning about terms and conditions
+    if not datastore_url:
+        cds_filepath = str(Path.home()) + "/.cdsapirc"
+        try:
+            with open(cds_filepath, "r") as file:
+                url = (
+                    file.read()
+                    .split("\n")[0]
+                    .split(" ")[1]
+                    .strip()
+                    .removesuffix("/api")
+                )
+        except FileNotFoundError as e:
+            raise FileNotFoundError("No .cdsapirc file in home directory.")
+    else:
+        if not datastore_url.endswith("/api"):
+            raise ValueError("The given datastore_url must end with /api.")
+        url = datastore_url.removesuffix("/api")
+    LOGGER.warning(
+        "Please ensure you have reviewed and accepted the terms and conditions "
+        "for the use of this dataset. Access the terms here: "
+        f"{url}/datasets/{dataset}?tab=download"
+    )
+
+    # Check if file exists and skip download if overwrite is False
+    if filename:
+        if Path(filename).exists() and not overwrite:
+            LOGGER.warning(f"File {filename} already exists. Skipping download.")
+            return
+
+    try:
+        # Initialize CDS API client
+        c = cdsapi.Client(url=datastore_url)
+        request = c.retrieve(dataset, params)
+
+        # prepare filename if not given
+        if not filename:
+            filename = DATA_DIR / f'{dataset}/{request.location.split("/")[-1]}'
+
+            # Check if file exists and skip download if overwrite is False
+            if Path(filename).exists() and not overwrite:
+                LOGGER.warning(f"File {filename} already exists. Skipping download.")
+                return
+
+        # make parent directory
+        output_dir = Path(filename).parent
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # download data
+        request.download(filename)
+
+        # Check if the file was successfully downloaded
+        if not Path(filename).exists():
+            raise FileNotFoundError(f"Failed to download {filename}.")
+
+        LOGGER.info(f"File successfully downloaded to {filename}.")
+
+        return filename
+
+    except Exception as e:
+        # user key is wrong
+        if "401 Client Error" in str(e):
+            error_message = (
+                "Authentification failed. Please ensure that the"
+                "API key in the .cdsapirc file is correct (see instructions)."
+            )
+        # dataset does not exist
+        elif "404 Client Error" in str(e):
+            error_message = f'Dataset "{url}/datasets/{dataset} not found. Please ensure the correct store and dataset.'
+        # terms not accepted
+        elif "403 Client Error" in str(e):
+            error_message = f"Required licences not accepted. Please accept here: {url}/datasets/{dataset}?tab=download"
+        # parameter choice not available
+        elif "MARS returned no data" in str(e):
+            error_message = "No data available for the given parameters. This may indicate unavailable or incorrect parameter selection. Please verify the existence of the data on the Climate Data Store website."
+        # general error
+        else:
+            error_message = f"Unexpected error downloading file {filename} (for common error sources, check out https://confluence.ecmwf.int/display/CKB/Common+Error+Messages+for+CDS+Requests). Error description: {str(e)}"
+
+        raise Exception(error_message)

--- a/climada_petals/hazard/copernicus_interface/downloader.py
+++ b/climada_petals/hazard/copernicus_interface/downloader.py
@@ -57,8 +57,8 @@ def download_data(dataset, params, filename=None, datastore_url=None, overwrite=
         The dataset to retrieve (e.g., 'seasonal-original-single-levels', 'sis-heat-and-cold-spells').
     params : dict
         Dictionary containing the parameters for the CDS API call (e.g., variables, time range, area).
-        To see which parameters are requested for the given dataset, ckeck out  in the "download" tab
-        of the dataset, tick all required parameter choices, and copy the "request" dict in the "API request" section.
+        To see which parameters are requested for the given dataset, go to the copernicus website of the dataset in the "download" tab,
+        tick all required parameter choices. You find the params dicts as "request" dict in the "API request" section.
     filename : pathlib.Path or str
         Full path and filename where the downloaded data will be stored. If None, data will be saved with the filename as suggested by the data store. Defaults to None.
     datastore_url : str
@@ -98,11 +98,6 @@ def download_data(dataset, params, filename=None, datastore_url=None, overwrite=
         if not datastore_url.endswith("/api"):
             raise ValueError("The given datastore_url must end with /api.")
         url = datastore_url.removesuffix("/api")
-    LOGGER.warning(
-        "Please ensure you have reviewed and accepted the terms and conditions "
-        "for the use of this dataset. Access the terms here: "
-        f"{url}/datasets/{dataset}?tab=download"
-    )
 
     # Check if file exists and skip download if overwrite is False
     if filename:
@@ -156,7 +151,7 @@ def download_data(dataset, params, filename=None, datastore_url=None, overwrite=
         elif "MARS returned no data" in str(e) or "400 Client Error" in str(e):
             error_message = (
                 "No data available for the given parameters. This may indicate unavailable or incorrect parameter selection. Please verify the existence of the data on the Climate Data Store website. "
-                f'You can find which parameters are requested for the given dataset by indicating all required parameter choices at {url}/datasets/{dataset}?tab=download, and copy the "request" keyword in the "API request" section.'
+                f'You can find which parameters are requested for the given dataset by indicating all required parameter choices at {url}/datasets/{dataset}?tab=download. The required params dict given in the "request" keyword in the "API request" section.'
             )
         # general error
         else:

--- a/climada_petals/hazard/copernicus_interface/downloader.py
+++ b/climada_petals/hazard/copernicus_interface/downloader.py
@@ -33,7 +33,7 @@ Prerequisites:
    https://cds.climate.copernicus.eu/how-to-api#install-the-cds-api-client
 
 4. Dataset Terms and Conditions: After selecting the dataset to download, make 
-   sure to accept the terms and conditions on the corresponding dataset webpage 
+   sure to accept the terms and conditions on the corresponding dataset webpage (under the "download" tab)
    in the CDS portal before running the script.
 """
 
@@ -48,7 +48,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def download_data(dataset, params, filename=None, datastore_url=None, overwrite=False):
-    """Download data from Copernicus Data Stores (e.g., ds.climate.copernicus.eu,
+    """Download data from Copernicus Data Stores (e.g., cds.climate.copernicus.eu,
     ads.atmosphere.copernicus.eu and ewds.climate.copernicus.eu) using specified dataset type and parameters.
 
     Parameters
@@ -57,6 +57,8 @@ def download_data(dataset, params, filename=None, datastore_url=None, overwrite=
         The dataset to retrieve (e.g., 'seasonal-original-single-levels', 'sis-heat-and-cold-spells').
     params : dict
         Dictionary containing the parameters for the CDS API call (e.g., variables, time range, area).
+        To see which parameters are requested for the given dataset, ckeck out  in the "download" tab
+        of the dataset, tick all required parameter choices, and copy the "request" dict in the "API request" section.
     filename : pathlib.Path or str
         Full path and filename where the downloaded data will be stored. If None, data will be saved with the filename as suggested by the data store. Defaults to None.
     datastore_url : str
@@ -64,6 +66,11 @@ def download_data(dataset, params, filename=None, datastore_url=None, overwrite=
     overwrite : bool, optional
         If True, overwrite the file if it already exists. If False, skip downloading
         if the file is already present. The default is False.
+
+    Returns
+    ----------
+    Path
+        Path to the downloaded file if the download was successfull.
 
     Raises
     ------
@@ -146,8 +153,11 @@ def download_data(dataset, params, filename=None, datastore_url=None, overwrite=
         elif "403 Client Error" in str(e):
             error_message = f"Required licences not accepted. Please accept here: {url}/datasets/{dataset}?tab=download"
         # parameter choice not available
-        elif "MARS returned no data" in str(e):
-            error_message = "No data available for the given parameters. This may indicate unavailable or incorrect parameter selection. Please verify the existence of the data on the Climate Data Store website."
+        elif "MARS returned no data" in str(e) or "400 Client Error" in str(e):
+            error_message = (
+                "No data available for the given parameters. This may indicate unavailable or incorrect parameter selection. Please verify the existence of the data on the Climate Data Store website. "
+                f'You can find which parameters are requested for the given dataset by indicating all required parameter choices at {url}/datasets/{dataset}?tab=download, and copy the "request" keyword in the "API request" section.'
+            )
         # general error
         else:
             error_message = f"Unexpected error downloading file {filename} (for common error sources, check out https://confluence.ecmwf.int/display/CKB/Common+Error+Messages+for+CDS+Requests). Error description: {str(e)}"


### PR DESCRIPTION
This is one part of the `copernicus_interface` module that is currently under development (see PR #142).

Changes proposed in this PR:
- Added function `download_data` to `climada_petals.hazard.copernicus_interface` module that accesses a Copernicus data store and downloads a dataset with user-given parameter ranges.

Notes and questions:
- We have thought about what unit tests to write but, expect for some type checking of the input parameters, we could not think of a useful unit test. We do not want the unit test to actually access a datastore. Any suggestions welcome!

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [x] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html#Static-Code-Analysis
