### PR TITLE
Add lxml dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Code freeze date: YYYY-MM-DD
 
 ### Dependency Changes
 
+Added:
+
+- `lxml` >=5 (was implicitly part of the dependency tree before)
+
 ### Added
 
 - Module `climada_petals.hazard.coastal_flood` with new Hazard class `CoastalFlood` and associated method `from_aqueduct_tif` to read coastal flood data directly from the Aqueduct tif files [#100](https://github.com/CLIMADA-project/climada_petals/pull/100)
@@ -19,6 +23,8 @@ Code freeze date: YYYY-MM-DD
 - Module `climada_petals.hazard.river_flood`, class `RiverFlood`: New method `from_aqueduct_tif` to read river flood data directly from the online Aqueduct tif files, and renamed methods `from_nc` to `from_isimip_nc` and `set_from_nc` to `set_from_isimip_nc` [#108](https://github.com/CLIMADA-project/climada_petals/pull/108)
 
 ### Fixed
+
+- Add `lxml` as explicit dependency [#168](https://github.com/CLIMADA-project/climada_petals/pull/168)
 
 ### Deprecated
 

--- a/climada_petals/hazard/tc_tracks_forecast.py
+++ b/climada_petals/hazard/tc_tracks_forecast.py
@@ -631,10 +631,9 @@ class TCForecast(TCTracks):
         if xsl_path is None:
             xsl_path = CXML2CSV_XSL
 
-        # coerce Path objects to str; coercion superfluous for lxml >= 4.8.0
         # pylint: disable= c-extension-no-member
-        xsl = et.parse(str(xsl_path))
-        xml = et.parse(str(cxml_path))
+        xsl = et.parse(xsl_path)
+        xml = et.parse(cxml_path)
         transformer = et.XSLT(xsl)
         csv_string = str(transformer(xml))
 

--- a/requirements/env_climada.yml
+++ b/requirements/env_climada.yml
@@ -8,6 +8,7 @@ dependencies:
   - esmpy>=8.4.2  # 8.4.1 has an issue with ESMFMKFILE env var being required
   - importlib-metadata<8.0  # 8.0 is incompatible with esmpy 8.4 (which is the only version available for windows 2024-07)
   - libgdal>=3.10
+  - lxml>=5
   - meson>=1.4,<1.5  # meson >=1.5 may break geoclaw setup (at least for python 3.11)
   - meson-python>=0.15,<0.16  # as of 2024-04 something seems to be wrong with 0.16
   - osm-flex>=1.1


### PR DESCRIPTION
Changes proposed in this PR:
- Add lxml as explicit dependency


This PR is needed because `pandas-datareader` was hiding the requirement in Petals. See https://github.com/CLIMADA-project/climada_python/pull/1033, where the Petals compatibility tests fail. 

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html#Static-Code-Analysis
