### PR TITLE
shapely.ops.cascaded_union removed in shapely 2.1

### DIFF
--- a/climada_petals/entity/exposures/black_marble.py
+++ b/climada_petals/entity/exposures/black_marble.py
@@ -313,7 +313,7 @@ def get_nightlight(ref_year, cntry_info, res_km=None, from_hr=None):
                     str(nl_year))
         res_fact = DEF_RES_NASA_KM / res_km
         geom = [info[2] for info in cntry_info.values()]
-        geom = shapely.ops.cascaded_union(geom)
+        geom = shapely.unary_union(geom)
         req_files = nl_utils.get_required_nl_files(geom.bounds)
         files_exist = nl_utils.check_nl_local_file_exists(req_files,
                                                              SYSTEM_DIR, nl_year)
@@ -401,7 +401,7 @@ def _cut_admin1(nightlight, lat, lon, admin1_geom, coord_nl, on_land):
     on_land_reg (2d array of same size as previous with True values on land
     points)
     """
-    all_geom = shapely.ops.cascaded_union(admin1_geom)
+    all_geom = shapely.unary_union(admin1_geom)
 
     in_lat = (math.floor((all_geom.bounds[1] - lat[0, 0]) / coord_nl[0, 1]),
               math.ceil((all_geom.bounds[3] - lat[0, 0]) / coord_nl[0, 1]))


### PR DESCRIPTION
Changes proposed in this PR:
- use unary_union instead

This PR fixes https://github.com/CLIMADA-project/climada_python/issues/1040

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/guide/Guide_Reviewer_Checklist.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html
[linter]: https://climada-python.readthedocs.io/en/latest/guide/Guide_Continuous_Integration_and_Testing.html#Static-Code-Analysis
