### PR TITLE
explicitly cast retrurn_period after clipping

### DIFF
--- a/climada_petals/hazard/rf_glofas/transform_ops.py
+++ b/climada_petals/hazard/rf_glofas/transform_ops.py
@@ -699,7 +699,7 @@ def flood_depth(
     # Clip infinite return periods
     return_period = return_period.clip(
         min=1, max=flood_maps["return_period"].max(), keep_attrs=True
-    )
+    ).astype(np.float32)
 
     # All but 'longitude' and 'latitude' are core dimensions for this operation
     core_dims = list(return_period.dims)


### PR DESCRIPTION
Changes proposed in this PR:
- assumedly with upgrade to numpy 2, the function `climada_petals.hazard.rf_glofas.transform_ops.flood_depth` started to
  fail with 
  ```
  TypeError: ufunc 'interpolate' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe'
  ```
- this PR fixes that by explicitly casting `return_period` after clipping it.

This PR fixes failing unit test `climada_petals.hazard.rf_glofas.test.test_transform_ops.TestTransformOps.test_flood_depth`

### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [x] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
