### PR TITLE
Update rf GloFAS module to download and process reforecasts

### DIFF
--- a/climada_petals/hazard/rf_glofas/cds_glofas_downloader.py
+++ b/climada_petals/hazard/rf_glofas/cds_glofas_downloader.py
@@ -66,6 +66,18 @@ DEFAULT_REQUESTS = {
         "day": ["01"],
         "leadtime_hour": (np.arange(1, 31) * 24).astype(str).tolist(),
     },
+    "reforecast": {
+        "variable": ["river_discharge_in_the_last_24_hours"],
+        "product_type": ["ensemble_perturbed_reforecast"],
+        "system_version": ["version_4_0"],
+        "hydrological_model": ["lisflood"],
+        "data_format": "grib2",
+        "download_format": "unarchived",
+        "hyear": ["1999"],
+        "hmonth": ["01"],
+        "hday": ["03"],
+        "leadtime_hour": (np.arange(1, 31) * 24).astype(str).tolist(),
+    },
 }
 """Default request keyword arguments to be updated by the user requests"""
 
@@ -77,7 +89,7 @@ def datetime_index_to_request(
     index: pd.DatetimeIndex, product: str
 ) -> dict[str, list[str]]:
     """Create a request-compatible dict from a series"""
-    prefix = "h" if product == "historical" else ""
+    prefix = "" if product == "forecast" else "h"
     return {
         prefix + "year": list(map(str, index.year.unique())),
         prefix + "month": list(map(lambda x: f"{x:02d}", index.month.unique())),
@@ -257,6 +269,10 @@ def glofas_request(
         raise NotImplementedError(
             f"product = {product}. Choose from {list(DEFAULT_REQUESTS.keys())}"
         ) from err
+
+    # Preflight status check: avoid misleading 400 invalid-request errors while a
+    # collection is unavailable on EWDS.
+    _check_ewds_collection_availability(glofas_product)
 
     # Update with request_kw
     if request_kw is not None:

--- a/climada_petals/hazard/rf_glofas/cds_glofas_downloader.py
+++ b/climada_petals/hazard/rf_glofas/cds_glofas_downloader.py
@@ -270,10 +270,6 @@ def glofas_request(
             f"product = {product}. Choose from {list(DEFAULT_REQUESTS.keys())}"
         ) from err
 
-    # Preflight status check: avoid misleading 400 invalid-request errors while a
-    # collection is unavailable on EWDS.
-    _check_ewds_collection_availability(glofas_product)
-
     # Update with request_kw
     if request_kw is not None:
         default_request.update(**request_kw)

--- a/climada_petals/hazard/rf_glofas/cds_glofas_downloader.py
+++ b/climada_petals/hazard/rf_glofas/cds_glofas_downloader.py
@@ -30,6 +30,7 @@ import logging
 import hashlib
 
 from cdsapi import Client
+import requests
 from ruamel.yaml import YAML
 from ruamel.yaml.compat import StringIO
 import pandas as pd
@@ -155,7 +156,11 @@ def glofas_request_single(
     if client_kw is not None:
         client_kw_default.update(client_kw)
     client = Client(**client_kw_default)
-    client.retrieve(product, request, outfile)
+    try:
+        client.retrieve(product, request, outfile)
+    except requests.exceptions.HTTPError as e:
+        LOGGER.error("Error occurred while retrieving data: %s, returning None", e)
+        return None
 
     # Dump request
     yaml = YAML()

--- a/climada_petals/hazard/rf_glofas/transform_ops.py
+++ b/climada_petals/hazard/rf_glofas/transform_ops.py
@@ -316,13 +316,25 @@ def download_glofas_discharge(
         request_kwargs["area"] = list(bounds)
 
     # Request the data
-    return glofas_request(
+    files = glofas_request(
         product=product,
         num_proc=num_proc,
         output_dir=download_path,
         request_kw=request_kwargs,
         requests=requests,
     )
+
+    # Strip None values from failed requests
+    files = [f for f in files if f is not None]
+    if len(files) == 0:
+        raise RuntimeError("All requests failed. No files were downloaded.")
+    elif len(files) < len(requests):
+        LOGGER.warning(
+            "Some requests failed. %d of %d requests were successful",
+            len(files),
+            len(requests),
+        )
+    return files
 
 
 def open_glofas_discharge(


### PR DESCRIPTION
Changes proposed in this PR:
- Adapt GloFAS river flood module to download and process reforecast data

@peanutfun I have started to draft the update of the GloFAS rf module to be able to process reforecasts. What I have done so far:
- Add default request dict for the reforecast product
- Add a try except block around the cems API call to not make the entire process fail when a wrong request is sent. This relaxes us from needing to understand the exact availability of reforecast data. Last time we checked, the availability seemed a bit random with reforecasts being available at an irregular frequency (see https://ewds.climate.copernicus.eu/datasets/cems-glofas-reforecast?tab=download). When the download fail, a `None` is returned. Not sure is this is the best way to handle it.

With these changes, we manage to download something, even though we get this somehow cryptic message:
```
2026-08-13 17:21:03,997 INFO [2024-11-11T00:00:00] Temporary freeze of medium-range reforecasts available from the EWDS, with no update of the dataset from GloFAS v4.2 release date. If you require access to the reforecast data, please get in touch with us via the [ECMWF Support Portal](https://confluence.ecmwf.int/site/support) using the title 'Access to GloFAS Reforecast Data' when creating the ticket. Information on how to raise a ticket in our support portal is available
[here](https://confluence.ecmwf.int/display/CEMS/CEMS-Flood+Data+Support).
```
Not sure if this matters for us or not.


### PR Author Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] Correct target branch selected (if unsure, select `develop`)
- [ ] Descriptive pull request title added
- [ ] Source branch up-to-date with target branch
- [ ] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [ ] [Tests][testing] updated
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]
- [ ] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
