### PR TITLE
perf: sparsify landslide event sampling instead of materialising the …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Code freeze date: YYYY-MM-DD
 ### Changed
 
 ### Fixed
+- `Landslide.sample_events` sparsifies each sampled year instead of building the whole simulation densely, reducing peak memory by 60x-120x in `Landslide.from_prob`. Output unchanged. [#35](https://github.com/CLIMADA-project/climada_petals/issues/35)
 
 ### Deprecated
 

--- a/climada_petals/hazard/landslide.py
+++ b/climada_petals/hazard/landslide.py
@@ -75,11 +75,13 @@ def sample_events(prob_matrix, n_years, dist='binom'):
     Landslide.from_prob()
     """
 
-    events = [
-        sample_event_from_probs(prob_matrix, n_samples=1, dist=dist)
+    # Sparsify each year as it is drawn: passing a list of dense rows to
+    # sparse.csr_matrix() holds two copies of the whole simulation at once.
+    rows = [
+        sparse.csr_matrix(sample_event_from_probs(prob_matrix, n_samples=1, dist=dist))
         for i in range(n_years)
         ]
-    return sparse.csr_matrix(events)
+    return sparse.vstack(rows, format="csr")
 
 
 def sample_event_from_probs(prob_matrix, n_samples, dist):
@@ -307,7 +309,8 @@ class Landslide(Hazard):
         # sample events from probabilities
         haz.intensity = sample_events(prob_matrix, n_years, dist)
         haz.fraction = haz.intensity.copy()
-        haz.fraction[haz.intensity.nonzero()] = 1
+        # the stored values are exactly the nonzeros, so no fancy-index needed
+        haz.fraction.data[:] = 1
         haz.frequency = np.ones(n_years) / n_years
 
         # meaningless, such that check() method passes:

--- a/climada_petals/hazard/test/test_landslide.py
+++ b/climada_petals/hazard/test/test_landslide.py
@@ -18,6 +18,7 @@ with CLIMADA. If not, see <https://www.gnu.org/licenses/>.
 
 Unit test landslide module.
 """
+import tracemalloc
 import unittest
 import geopandas as gpd
 import numpy as np
@@ -238,6 +239,35 @@ class TestLandslideModule(unittest.TestCase):
                 break
         self.assertTrue(events[events.nonzero()].max() <= 1)  # fails for all-zero-events
         self.assertEqual(events.shape, (n_years, prob_matrix.shape[0]))
+
+    def test_sample_events_is_sparse(self):
+        """Peak memory tracks the result, not n_years x n_pixels."""
+        _meta, prob_matrix = u_coord.read_raster(
+            LS_PROB_FILE, geometry=[shapely.geometry.box(8, 45, 11, 46)])
+        prob_matrix = prob_matrix.squeeze() / 10e6
+        n_years = 500
+        n_pixels = prob_matrix.shape[0]
+        dense_bytes = n_years * n_pixels * 8
+
+        tracemalloc.start()
+        events = sample_events(prob_matrix, n_years, dist='binom')
+        _current, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        self.assertEqual(events.shape, (n_years, n_pixels))
+        self.assertLess(peak, dense_bytes / 10)
+
+    def test_from_prob_fraction_marks_intensity(self):
+        """fraction is 1 exactly where intensity is stored."""
+        np.random.seed(42)
+        haz = Landslide.from_prob(bbox=(8, 45, 11, 46),
+                                  path_sourcefile=LS_PROB_FILE, n_years=500,
+                                  dist='binom')
+
+        self.assertGreater(haz.fraction.nnz, 0)
+        self.assertEqual(haz.fraction.nnz, haz.intensity.nnz)
+        np.testing.assert_array_equal(np.unique(haz.fraction.data), np.array([1]))
+        np.testing.assert_array_equal(haz.fraction.nonzero(), haz.intensity.nonzero())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changes proposed in this PR:
- `sample_events` sparsifies each sampled year and `vstack`s the rows, instead of passing a list of `n_years` dense rows to `sparse.csr_matrix`.
- `from_prob` sets `fraction.data` directly instead of using a CSR fancy-index assignment.
- Two tests, one bounding peak memory as a regression guard.

This PR fixes #35

`prob_matrix` reaches `sample_events` dense, and each draw returns one dense year. So when `sparse.csr_matrix(events)` runs there are two full copies of the simulation alive: the list of dense rows, and the dense `(n_years, n_pixels)` array scipy builds from it before compressing. Peak is `2 x n_years x n_pixels x 8` bytes however rare landslides are 695 MB at 1 000 years on the packaged raster, for a result holding 13 nonzeros.

`Landslide.from_prob` on the repo's `test_ls_prob.tif` (43 200 px), old and new in one process, memory and time measured separately:

```
                              peak old  peak new      less    t old    t new
                                  (MB)      (MB)               (ms)     (ms)
sample_events, 100 yr             69.1       1.0     69.1x       78       71    1.10x
sample_events, 500 yr            345.7       1.3    266.1x      393      356    1.11x
sample_events, 1000 yr           691.4       1.7    406.9x      785      709    1.11x
from_prob, 500 yr                349.5       5.3     66.1x      407      369    1.10x
from_prob, 1000 yr               695.2       5.5    126.6x      799      727    1.10x
```

The ratio grows with `n_years x n_pixels`; the old peak scales with the problem, the new one with the result.

**Negligible speed up:** it reads ~1.10x here, but in previous tests it has been 0.95x so the impact on speed is mainly noise. But that isn't a problem because the improvement on memory is way larger. The call is dominated by `n_years` scipy `rvs` invocations, which this does not touch, so no time effect is the claim I would defend.

**Output is bit-identical.** `sample_event_from_probs` is called the same number of times, in the same order, with the same arguments; nothing touches the RNG. Verified for both distributions at 100 and 500 years. A variant drawing `k` years per vectorised `rvs` call was measured too, same time and only 11.8x less peak, and rejected because it changes the draw order.

Two notes on the issue. It suggests the sampler *"destroys the sparse matrix"*, but nothing upstream is sparse; the cost is the two dense copies. And #39 modified this function in 2022 without changing that construction, which matches @chahank's doubt at the time that #39 would resolve this.

The memory guard's bound derives from `n_years x n_pixels x 8 bytes` and fails on the current implementation with `AssertionError: 345678407 not less than 17280000.0`. The second test covers `from_prob`'s `fraction` deterministically; the equivalent assertions in `test_from_prob` sit behind `if LS_prob.intensity.size`, which is `nnz` for a sparse matrix, so they are skipped when a draw produces nothing. That is a separate test-hygiene issue.

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
