### PR TITLE
Fixes wrong underscore in error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Code freeze date: YYYY-MM-DD
 ### Changed
 
 ### Fixed
+- Fixed a wrong error message on required MRIOT name format in the supplychain module ("_" instead of "-") [#205](https://github.com/CLIMADA-project/climada_petals/pull/205)
 
 ### Deprecated
 

--- a/climada_petals/engine/supplychain/mriot_handling.py
+++ b/climada_petals/engine/supplychain/mriot_handling.py
@@ -736,7 +736,7 @@ def _get_coco_MRIOT_name(mriot_name, is_custom=False):
     match = MRIOT_FULLNAME_REGEX.match(mriot_name)
     if not match:
         raise ValueError(
-            f"Input string '{mriot_name}' is not in the correct format '<MRIOT-name>_<year>' or not recognized."
+            f"Input string '{mriot_name}' is not in the correct format '<MRIOT-name>-<year>' or not recognized."
         )
 
     mriot_type = match.group("mrio_type")


### PR DESCRIPTION
This PR fixes an error message which wrongly states that required MRIOT name format is `<MRIOT-name>_<year>` instead of `<MRIOT-name>-<year>`

### PR Author Checklist

- [x] Read the [Contribution Guide][contrib]
- [x] Correct target branch selected (if unsure, select `develop`)
- [x] Descriptive pull request title added
- [x] Source branch up-to-date with target branch
- [x] [Documentation](https://climada-python.readthedocs.io/en/latest/guide/Guide_PythonDos-n-Donts.html#2.--Commenting-&-Documenting) updated
- [x] [Tests][testing] updated
- [x] [Tests][testing] passing
- [x] No new [linter issues][linter]
- [x] [Changelog](https://github.com/CLIMADA-project/climada_petals/blob/main/CHANGELOG.md) updated

### PR Reviewer Checklist

- [ ] Read the [Contribution Guide][contrib]
- [ ] [CLIMADA Reviewer Checklist](https://climada-python.readthedocs.io/en/latest/development/Guide_Review.html) passed
- [ ] [Tests][testing] passing
- [ ] No new [linter issues][linter]

[contrib]: https://github.com/CLIMADA-project/climada_python/blob/main/CONTRIBUTING.md
[testing]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html
[linter]: https://climada-python.readthedocs.io/en/latest/development/Guide_continuous_integration_GitHub_actions.html#static-code-analysis
